### PR TITLE
[#156733324] Update App Display Name

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">pulsemobile</string>
+    <string name="app_name">Pulse</string>
 </resources>

--- a/ios/pulsemobile/Info.plist
+++ b/ios/pulsemobile/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>pulsemobile</string>
+	<string>Pulse</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
### What does this PR do?
Updates App Display Name from the `pulsemobile` to `Pulse`

### How should this be manually tested?
 -  run `react-native run-android` and `react-native run-ios` to check icons for android and ios respectively.
- navigate to simulator / phone menu to view the App Name in app listings

### What are the relevant pivotal tracker stories?
[#156733324](https://www.pivotaltracker.com/story/show/156733324)

### Screenshots (if appropriate)
![screen shot 2018-04-12 at 20 12 05](https://user-images.githubusercontent.com/17447937/38692940-0c5ac7b6-3e8e-11e8-9b4a-affd68d37487.png)
![screen shot 2018-04-12 at 20 12 15](https://user-images.githubusercontent.com/17447937/38692959-1b032e70-3e8e-11e8-9eb0-5edd2de7eef7.png)

